### PR TITLE
Fix typo, Gfile.Size() to Gfile.size()

### DIFF
--- a/input_data.py
+++ b/input_data.py
@@ -37,7 +37,7 @@ def maybe_download(filename, work_directory):
   if not tf.gfile.Exists(filepath):
     filepath, _ = urllib.request.urlretrieve(SOURCE_URL + filename, filepath)
     with tf.gfile.GFile(filepath) as f:
-      size = f.Size()
+      size = f.size()
     print('Successfully downloaded', filename, size, 'bytes.')
   return filepath
 


### PR DESCRIPTION
Just a typo. I was thinking that this method Size() was of another tensorflow version, but it appears to be with lower case initials.